### PR TITLE
docs: Fix docgen script and URLs

### DIFF
--- a/docgen.ps1
+++ b/docgen.ps1
@@ -27,6 +27,7 @@ xmldoc2md ./src/CloudLab.SDK.MongoDB/bin/Release/net6.0/CloudLab.SDK.MongoDB.dll
 Write-Host "Updating URLS on auto-generated Markdown files for CloudLab.SDK.SaaS wiki..." -Foreground yellow
 $FILE_PATH = "./src/CloudLab.SDK.SaaS/bin/Release/net6.0/docs/*.md"
 Get-ChildItem $FILE_PATH -Recurse | ForEach-Object { (Get-Content $_).Replace("(./cloudlab.sdk.saas", "(https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas") | Set-Content $_ }
+Get-ChildItem $FILE_PATH -Recurse | ForEach-Object { (Get-Content $_).Replace(".md)", ")") | Set-Content $_ }
 
 Write-Host "Copying auto-generated Markdown files for CloudLab.SDK.SaaS wiki..." -Foreground yellow
 $FILES = Copy-Item -Path ./src/CloudLab.SDK.SaaS/bin/Release/net6.0/docs/* -Destination ./wiki -Exclude index.md -Force -PassThru | ?{$_ -is [System.IO.FileInfo]}
@@ -44,6 +45,8 @@ Remove-Item ./src/CloudLab.SDK.SaaS/bin/Release/net6.0/docs/ -Recurse
 Write-Host "Updating URLS on auto-generated Markdown files for CloudLab.SDK.MongoDB wiki..." -Foreground yellow
 $FILE_PATH = "./src/CloudLab.SDK.MongoDB/bin/Release/net6.0/docs/*.md"
 Get-ChildItem $FILE_PATH -Recurse | ForEach-Object { (Get-Content $_).Replace("(./cloudlab.sdk.mongodb", "(https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.mongodb") | Set-Content $_ }
+Get-ChildItem $FILE_PATH -Recurse | ForEach-Object { (Get-Content $_).Replace(".md)", ")") | Set-Content $_ }
+
 
 Write-Host "Copying auto-generated Markdown files for CloudLab.SDK.MongoDB wiki..." -Foreground yellow
 $FILES = Copy-Item -Path ./src/CloudLab.SDK.MongoDB/bin/Release/net6.0/docs/* -Destination ./wiki -Exclude index.md -Force -PassThru | ?{$_ -is [System.IO.FileInfo]}

--- a/docgen.ps1
+++ b/docgen.ps1
@@ -47,7 +47,6 @@ $FILE_PATH = "./src/CloudLab.SDK.MongoDB/bin/Release/net6.0/docs/*.md"
 Get-ChildItem $FILE_PATH -Recurse | ForEach-Object { (Get-Content $_).Replace("(./cloudlab.sdk.mongodb", "(https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.mongodb") | Set-Content $_ }
 Get-ChildItem $FILE_PATH -Recurse | ForEach-Object { (Get-Content $_).Replace(".md)", ")") | Set-Content $_ }
 
-
 Write-Host "Copying auto-generated Markdown files for CloudLab.SDK.MongoDB wiki..." -Foreground yellow
 $FILES = Copy-Item -Path ./src/CloudLab.SDK.MongoDB/bin/Release/net6.0/docs/* -Destination ./wiki -Exclude index.md -Force -PassThru | ?{$_ -is [System.IO.FileInfo]}
 $FILES

--- a/wiki/SDK-Documentation.md
+++ b/wiki/SDK-Documentation.md
@@ -1,9 +1,9 @@
 # CloudLab.SDK.SaaS Documentation
 This is the index page of the source-code documentation for the the following libraries:
 
-- [CloudLab.SDK.SaaS](./docs/cloudlab.sdk.saas.index.md): The core building blocks of any SaaS or Micro-SaaS, containing all the basics for the solution implementations.
+- [CloudLab.SDK.SaaS](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.index): The core building blocks of any SaaS or Micro-SaaS, containing all the basics for the solution implementations.
   - This is the main package where all the core implementations are located. All other packages available and deployed from this repository  depend upon this one.
-- [CloudLab.SDK.MongoDB](./docs/cloudlab.sdk.mongodb.index.md): The MongoDB NoSQL building blocks.
+- [CloudLab.SDK.MongoDB](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.mongodb.index): The MongoDB NoSQL building blocks.
   - This is the package where you can find wrappers to deal with MongoDB operations through [MongoDB.Driver](https://www.nuget.org/packages/MongoDB.Driver), version ![mongodb_nugetversion](https://img.shields.io/nuget/v/MongoDB.Driver).
 
 # Package Versions

--- a/wiki/cloudlab.sdk.saas.context.context.md
+++ b/wiki/cloudlab.sdk.saas.context.context.md
@@ -11,8 +11,8 @@ This type of context is a read-write informational context.
 public abstract class Context : IContext, IContextId, CloudLab.SDK.SaaS.Core.IInitialization
 ```
 
-Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [Context](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.context.md)<br>
-Implements [IContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontext.md), [IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid.md), [IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization.md)
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [Context](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.context)<br>
+Implements [IContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontext), [IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid), [IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization)
 
 **Remarks:**
 
@@ -61,7 +61,7 @@ public bool IsInitialized { get; }
 
 ### **Context()**
 
-Initializes a new instance of the [Context](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.context.md) class.
+Initializes a new instance of the [Context](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.context) class.
 
 ```csharp
 public Context()
@@ -87,4 +87,4 @@ public abstract IImmutableContext ToImmutableContext()
 
 #### Returns
 
-[IImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.iimmutablecontext.md)<br>
+[IImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.iimmutablecontext)<br>

--- a/wiki/cloudlab.sdk.saas.context.icontext.md
+++ b/wiki/cloudlab.sdk.saas.context.icontext.md
@@ -11,7 +11,7 @@ This type of context is a read-write informational context.
 public interface IContext : IContextId, CloudLab.SDK.SaaS.Core.IInitialization
 ```
 
-Implements [IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid.md), [IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization.md)
+Implements [IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid), [IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization)
 
 **Remarks:**
 
@@ -51,6 +51,6 @@ IImmutableContext ToImmutableContext()
 
 #### Returns
 
-[IImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.iimmutablecontext.md)<br>
+[IImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.iimmutablecontext)<br>
 Returns a  representing the converted read-only immutable
             context or null when the current context could not be converted to a read-only immutable context.

--- a/wiki/cloudlab.sdk.saas.context.iimmutablecontext.md
+++ b/wiki/cloudlab.sdk.saas.context.iimmutablecontext.md
@@ -11,7 +11,7 @@ This type of context is a read-only immutable informational context.
 public interface IImmutableContext : IContextId, CloudLab.SDK.SaaS.Core.IInitialization
 ```
 
-Implements [IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid.md), [IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization.md)
+Implements [IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid), [IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization)
 
 **Remarks:**
 
@@ -56,6 +56,6 @@ IContext ToContext()
 
 #### Returns
 
-[IContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontext.md)<br>
+[IContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontext)<br>
 Returns a  representing the converted read-write context or 
             null when the current context could not be converted to a read-write context.

--- a/wiki/cloudlab.sdk.saas.context.immutablecontext.md
+++ b/wiki/cloudlab.sdk.saas.context.immutablecontext.md
@@ -11,8 +11,8 @@ This type of context is a read-only immutable informational context.
 public abstract class ImmutableContext : IImmutableContext, IContextId, CloudLab.SDK.SaaS.Core.IInitialization
 ```
 
-Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [ImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.immutablecontext.md)<br>
-Implements [IImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.iimmutablecontext.md), [IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid.md), [IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization.md)
+Inheritance [Object](https://docs.microsoft.com/en-us/dotnet/api/system.object) → [ImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.immutablecontext)<br>
+Implements [IImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.iimmutablecontext), [IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid), [IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization)
 
 **Remarks:**
 
@@ -61,7 +61,7 @@ public bool IsInitialized { get; }
 
 ### **ImmutableContext(Guid, Dictionary&lt;String, Object&gt;)**
 
-Initializes a new instance of the [ImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.immutablecontext.md) class with the
+Initializes a new instance of the [ImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.immutablecontext) class with the
  specified [Guid](https://docs.microsoft.com/en-us/dotnet/api/system.guid) and [Dictionary&lt;TKey, TValue&gt;](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2) used as default
  values for the properties [ImmutableContext.ContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.immutablecontext.md#contextid) and [ImmutableContext.Properties](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.immutablecontext.md#properties), respectively.
 
@@ -97,4 +97,4 @@ public abstract IContext ToContext()
 
 #### Returns
 
-[IContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontext.md)<br>
+[IContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontext)<br>

--- a/wiki/cloudlab.sdk.saas.index.md
+++ b/wiki/cloudlab.sdk.saas.index.md
@@ -3,16 +3,16 @@ This is the index page of the source-code documentation for the **CloudLab.SDK.S
 
 ## CloudLab.SDK.SaaS.Context
 
-[Context](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.context.md)
+[Context](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.context)
 
-[IContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontext.md)
+[IContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontext)
 
-[IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid.md)
+[IContextId](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.icontextid)
 
-[IImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.iimmutablecontext.md)
+[IImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.iimmutablecontext)
 
-[ImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.immutablecontext.md)
+[ImmutableContext](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.context.immutablecontext)
 
 ## CloudLab.SDK.SaaS.Core
 
-[IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization.md)
+[IInitialization](https://github.com/cloudlabtech/SDK-SaaS/wiki/cloudlab.sdk.saas.core.iinitialization)


### PR DESCRIPTION
# Description

- Removed the ".md" suffix of URLs on wiki pages
- Minor URL fixes on wiki pages
- Hopefully the last fix on docgen.ps1 related to wiki URLs :heart: :angry:

## Type of change(s)
- [X] This change only refer to documentation contents

# Change(s) Checklist:

- [X] I have made corresponding changes to the documentation